### PR TITLE
change picture media type detection to tika instead of plain java

### DIFF
--- a/helfomat-web/pom.xml
+++ b/helfomat-web/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>1.22</version>
+        </dependency>
+        <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
             <version>${springfox-swagger2.version}</version>

--- a/helfomat-web/src/main/java/de/helfenkannjeder/helfomat/web/controller/PictureController.java
+++ b/helfomat-web/src/main/java/de/helfenkannjeder/helfomat/web/controller/PictureController.java
@@ -2,6 +2,7 @@ package de.helfenkannjeder.helfomat.web.controller;
 
 import de.helfenkannjeder.helfomat.core.picture.PictureId;
 import de.helfenkannjeder.helfomat.core.picture.PictureRepository;
+import org.apache.tika.Tika;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,7 @@ import java.nio.file.Path;
 @RequestMapping("/api")
 public class PictureController {
 
+    private static final Tika TIKA = new Tika();
     private final PictureRepository pictureRepository;
 
     public PictureController(PictureRepository pictureRepository) {
@@ -43,7 +45,7 @@ public class PictureController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
         final HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.parseMediaType(Files.probeContentType(picture)));
+        headers.setContentType(MediaType.parseMediaType(TIKA.detect(picture)));
         InputStream inputStream = Files.newInputStream(picture);
         return new ResponseEntity<>(new InputStreamResource(inputStream), headers, HttpStatus.OK);
     }


### PR DESCRIPTION
plain java is often unreliable and returns `null` instead of the
correct media type. Therefore now tika is used, see also:
https://stackoverflow.com/questions/51438/getting-a-files-mime-type-in-java